### PR TITLE
Fix InlineKeyboardButtonArray

### DIFF
--- a/src/Telegram/Types/Custom/InlineKeyboardButtonArray.php
+++ b/src/Telegram/Types/Custom/InlineKeyboardButtonArray.php
@@ -17,8 +17,12 @@ class InlineKeyboardButtonArray extends CustomType implements CustomArrayType
     public function __construct(array $data = null, LoggerInterface $logger = null)
     {
         if (count($data) !== 0) {
-            foreach ($data as $rowId => $button) {
-                $this->data[$rowId][] = new Button($data, $logger);
+            foreach ($data as $rowId => $buttons) {
+                $rowButtons = [];
+                foreach ($buttons as $button) {
+                    $rowButtons[] = new Button($button, $logger);
+                }
+                $this->data[$rowId] = $rowButtons;
             }
         }
     }


### PR DESCRIPTION
Seems like now it's broken.

With this PR we can create buttons like this:
```php
$markup = new Markup([
    'inline_keyboard' => [
        [
            ['text' => '1', 'callback_data' => 'k=1'],
            ['text' => '2', 'callback_data' => 'k=2'],
        ],
        [
            ['text' => '3', 'callback_data' => 'k=3'],
            ['text' => '4', 'callback_data' => 'k=4'],
        ]
    ]
]);
$sendMessage->reply_markup = $markup;
```
![2017-06-04_18-49-35](https://cloud.githubusercontent.com/assets/347306/26763177/fe8ddef2-4956-11e7-80ae-5d2006b99363.png)

