### PR TITLE
Remove random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
     "react/promise": "^2.7",
     "clue/block-react": "^1.3",
     "yoshi2889/multipart-builder": "^0.1.1",
-    "amphp/artax": "^3",
-    "paragonie/random_compat": "1.2.2"
+    "amphp/artax": "^3"
   },
   "require-dev": {
     "monolog/monolog": "^1.17",


### PR DESCRIPTION
This is no longer necessary as PHP 7.0 is the minimum required PHP version.

It also conflicts with roave/security-advisories due to a known security weakness.

https://github.com/FriendsOfPHP/security-advisories/blob/9280c6d9a669f7142cbe9ea12469fb40d98c0e3b/paragonie/random_compat/2016-03-16.yaml