### PR TITLE
Pr/attachments fclose

### DIFF
--- a/examples/send-document-custom-name.php
+++ b/examples/send-document-custom-name.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types = 1);
+
+include __DIR__.'/basics.php';
+
+use React\EventLoop\Factory;
+use unreal4u\TelegramAPI\HttpClientRequestHandler;
+use unreal4u\TelegramAPI\Telegram\Methods\SendDocument;
+use unreal4u\TelegramAPI\Telegram\Types\Custom\InputFile;
+use unreal4u\TelegramAPI\TgLog;
+
+$loop = Factory::create();
+$tgLog = new TgLog(BOT_TOKEN, new HttpClientRequestHandler($loop));
+
+// File name shown in Telegram clients has exactly same name as file is saved on system. So if we want to upload
+// file but with different name, we have to rename it or in this example, copy it as new name.
+// Later, after Telegram request is completed, temporary file can be easily deleted
+$tempFilePath = sprintf('%s/binary-test-data/%s/custom-file-name.txt', __DIR__, uniqid());
+mkdir(dirname($tempFilePath));
+copy(__FILE__, $tempFilePath);
+
+$sendDocument = new SendDocument();
+$sendDocument->chat_id = A_USER_CHAT_ID;
+$sendDocument->document = new InputFile($tempFilePath);
+$sendDocument->parse_mode = 'HTML';
+$sendDocument->caption = sprintf('Uploaded file was originaly named as <b>%s</b> but display name in Telegram client is <b>%s</b>', basename(__FILE__), basename($tempFilePath));
+
+$promise = $tgLog->performApiRequest($sendDocument);
+
+$promise->then(
+    function ($response) use ($tempFilePath) {
+        echo '<pre>';
+        var_dump($response);
+        echo '</pre>';
+
+        // Delete temporary file and directory after upload to Telegram server is completed
+        if (@unlink($tempFilePath) && @rmdir(dirname($tempFilePath))) {
+            var_dump('Temporary file and folder were deleted.');
+        } else {
+            var_dump('Error while deleting temporary file or directory:', error_get_last());
+        }
+    },
+    function (\Exception $exception) {
+        // Onoes, an exception occurred...
+        echo 'Exception ' . get_class($exception) . ' caught, message: ' . $exception->getMessage();
+    }
+);
+
+$loop->run();

--- a/src/InternalFunctionality/PostOptionsConstructor.php
+++ b/src/InternalFunctionality/PostOptionsConstructor.php
@@ -170,6 +170,7 @@ class PostOptionsConstructor
                 stream_get_contents($mediaStream['stream']),
                 pathinfo($mediaStream['filename'], PATHINFO_BASENAME)
             );
+            fclose($mediaStream['stream']);
 
             $builder->append($appendingData);
         }


### PR DESCRIPTION
If some file is added using `unreal4u\TelegramAPI\Telegram\Types\Custom\InputFile()`, file is locked using `fopen()` and read via `stream_get_contents()` but it is never closed. Usually it doesn't matter, because lock is released once PHP script is finished but in specific situations, it is causing troubles. Steps to reproduce:

1. create directory `some-dir`
1. create file `some-dir/some.file` 
1. upload it using `InputFile()` and `SendDocument()`
1. delete file `some-dir/some.file` (file is really deleted)
1. delete directory `some-dir` (warning will occure, that `Directory is not empty` and directory is **not** deleted)

In this PR I also added real example with these steps, see `examples/send-document-custom-name.php`. 

### Disclaimer

It seems, that warning is occuring only on Windows not on Linux, can someone run more tests?
Tested on:
- Windows 10, PHP 7.3.21, 7.4.9 and 8.0.9
- Linux Ubuntu 20.04.3, PHP 7.4.3  