### PR TITLE
TelegramTypes ChatMember updates

### DIFF
--- a/src/Telegram/Methods/GetChatMember.php
+++ b/src/Telegram/Methods/GetChatMember.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace unreal4u\TelegramAPI\Telegram\Methods;
 
@@ -11,9 +11,8 @@ use unreal4u\TelegramAPI\InternalFunctionality\TelegramResponse;
 use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
 
 /**
- * Use this method to get information about a member of a chat. Returns a ChatMember object on success
- *
- * Objects defined as-is july 2016
+ * Use this method to get information about a member of a chat. The method is only guaranteed to work for other users
+ * if the bot is an administrator in the chat. Returns a ChatMember object on success.
  *
  * @see https://core.telegram.org/bots/api#getchatmember
  */
@@ -22,7 +21,7 @@ class GetChatMember extends TelegramMethods
     /**
      * Unique identifier for the target chat or username of the target supergroup or channel (in the format
      * @channelusername)
-     * @var string
+     * @var int|string
      */
     public $chat_id = '';
 
@@ -34,7 +33,7 @@ class GetChatMember extends TelegramMethods
 
     public static function bindToObject(TelegramResponse $data, LoggerInterface $logger): TelegramTypes
     {
-        return new ChatMember($data->getResult(), $logger);
+        return ChatMember::create($data->getResult(), $logger);
     }
 
     public function getMandatoryFields(): array

--- a/src/Telegram/Types/Chat.php
+++ b/src/Telegram/Types/Chat.php
@@ -15,6 +15,11 @@ use unreal4u\TelegramAPI\Abstracts\TelegramTypes;
  */
 class Chat extends TelegramTypes
 {
+    public const TYPE_PRIVATE = 'private';
+    public const TYPE_GROUP = 'group';
+    public const TYPE_SUPERGROUP = 'supergroup';
+    public const TYPE_CHANNEL = 'channel';
+
     /**
      * Unique identifier for this chat. This number may be greater than 32 bits and some programming languages may have
      * difficulty/silent defects in interpreting it. But it smaller than 52 bits, so a signed 64 bit integer or

--- a/src/Telegram/Types/ChatMember/ChatMemberAdministrator.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberAdministrator.php
@@ -104,6 +104,24 @@ class ChatMemberAdministrator extends ChatMember
     public $can_pin_messages = false;
 
     /**
+     * Optional. True, if the administrator can post stories in the channel; channels only
+     * @var bool
+     */
+    public $can_post_stories = false;
+
+    /**
+     * Optional. True, if the administrator can edit stories posted by other users; channels only
+     * @var bool
+     */
+    public $can_edit_stories = false;
+
+    /**
+     * Optional. True, if the administrator can delete stories posted by other users; channels only
+     * @var bool
+     */
+    public $can_delete_stories = false;
+
+    /**
      * Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
      * @var bool
      */

--- a/src/Telegram/Types/ChatMember/ChatMemberAdministrator.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberAdministrator.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that has some additional privileges.
+ *
+ * @see https://core.telegram.org/bots/api#chatmemberadministrator
+ */
+class ChatMemberAdministrator extends ChatMember
+{
+    public const STATUS = 'administrator';
+
+    /**
+     * The member's status in the chat, always “administrator”
+     * @var string
+     */
+    public $status = self::STATUS;
+
+    /**
+     * True, if the bot is allowed to edit administrator privileges of that user
+     * @var bool
+     */
+    public $can_be_edited = false;
+
+    /**
+     * True, if the user's presence in the chat is hidden
+     * @var bool
+     */
+    public $is_anonymous = false;
+
+    /**
+     * True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see
+     * channel members, see anonymous administrators in supergroups and ignore slow mode.
+     * Implied by any other administrator privilege
+     * @var bool
+     */
+    public $can_manage_chat = false;
+
+    /**
+     * True, if the administrator can delete messages of other users
+     * @var bool
+     */
+    public $can_delete_messages = false;
+
+    /**
+     * True, if the administrator can manage video chats
+     * @var bool
+     */
+    public $can_manage_video_chats = false;
+
+    /**
+     * @deprecated Use can_manage_video_chats instead (April 16, 2022 Bot API 6.0 https://core.telegram.org/bots/api-changelog#april-16-2022)
+     * @var bool
+     */
+    public $can_manage_voice_chats = false;
+
+    /**
+     * True, if the administrator can restrict, ban or unban chat members
+     * @var bool
+     */
+    public $can_restrict_members = false;
+
+    /**
+     * True, if the administrator can add new administrators with a subset of their own privileges or demote
+     * administrators that they have promoted, directly or indirectly (promoted by administrators that were appointed
+     * by the user)
+     * @var bool
+     */
+    public $can_promote_members = false;
+
+    /**
+     * True, if the user is allowed to change the chat title, photo and other settings
+     * @var bool
+     */
+    public $can_change_info = false;
+
+    /**
+     * True, if the user is allowed to invite new users to the chat
+     * @var bool
+     */
+    public $can_invite_users = false;
+
+    /**
+     * Optional. True, if the administrator can post in the channel; channels only
+     * @var bool
+     */
+    public $can_post_messages = false;
+
+    /**
+     * Optional. True, if the administrator can edit messages of other users and can pin messages; channels only
+     * @var bool
+     */
+    public $can_edit_messages = false;
+
+    /**
+     * Optional. True, if the user is allowed to pin messages; groups and supergroups only
+     * @var bool
+     */
+    public $can_pin_messages = false;
+
+    /**
+     * Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
+     * @var bool
+     */
+    public $can_manage_topics = false;
+
+    /**
+     * Optional. Custom title for this user
+     * @var string
+     */
+    public $custom_title;
+}

--- a/src/Telegram/Types/ChatMember/ChatMemberBanned.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberBanned.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that was banned in the chat and can't return to the chat or view chat messages.
+ *
+ * @see https://core.telegram.org/bots/api#chatmemberbanned
+ */
+class ChatMemberBanned extends ChatMember
+{
+    public const STATUS = 'kicked';
+
+    /**
+     * The member's status in the chat, always “kicked”
+     * @var string
+     */
+    public $status = self::STATUS;
+
+    /**
+     * Date when restrictions will be lifted for this user; Unix time. If 0, then the user is banned forever
+     * @var int
+     */
+    public $until_date = 0;
+}

--- a/src/Telegram/Types/ChatMember/ChatMemberLeft.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberLeft.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that isn't currently a member of the chat, but may join it themselves.
+ *
+ * @see https://core.telegram.org/bots/api#chatmemberleft
+ */
+class ChatMemberLeft extends ChatMember
+{
+    public const STATUS = 'left';
+
+    /**
+     * The member's status in the chat, always “left”
+     * @var string
+     */
+    public $status = self::STATUS;
+}

--- a/src/Telegram/Types/ChatMember/ChatMemberMember.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberMember.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that has no additional privileges or restrictions.
+ *
+ * @see https://core.telegram.org/bots/api#chatmembermember
+ */
+class ChatMemberMember extends ChatMember
+{
+    public const STATUS = 'member';
+
+    /**
+     * The member's status in the chat, always “member”
+     * @var string
+     */
+    public $status = self::STATUS;
+}

--- a/src/Telegram/Types/ChatMember/ChatMemberOwner.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberOwner.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that has some additional privileges.
+ *
+ * @see https://core.telegram.org/bots/api#chatmemberowner
+ */
+class ChatMemberOwner extends ChatMember
+{
+    public const STATUS = 'creator';
+
+    /**
+     * The member's status in the chat, always “creator”
+     * @var string
+     */
+    public $status = self::STATUS;
+
+    /**
+     * True, if the user's presence in the chat is hidden
+     * @var bool
+     */
+    public $is_anonymous = false;
+
+    /**
+     * Optional. Custom title for this user
+     * @var string
+     */
+    public $custom_title;
+}

--- a/src/Telegram/Types/ChatMember/ChatMemberRestricted.php
+++ b/src/Telegram/Types/ChatMember/ChatMemberRestricted.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+use unreal4u\TelegramAPI\Telegram\Types\ChatMember;
+
+/**
+ * Represents a chat member that is under certain restrictions in the chat. Supergroups only.
+ *
+ * @see https://core.telegram.org/bots/api#chatmemberrestricted
+ */
+class ChatMemberRestricted extends ChatMember
+{
+    public const STATUS = 'restricted';
+
+    /**
+     * The member's status in the chat, always “restricted”
+     * @var string
+     */
+    public $status = self::STATUS;
+
+    /**
+     * True, if the user is a member of the chat at the moment of the request
+     * @var bool
+     */
+    public $is_member = false;
+
+    /**
+     * True, if the user is allowed to send text messages, contacts, invoices, locations and venues
+     * @var bool
+     */
+    public $can_can_send_messages = false;
+
+    /**
+     * True, if the user is allowed to send audios
+     * @var bool
+     */
+    public $can_send_audios = false;
+
+    /**
+     * True, if the user is allowed to send documents
+     * @var bool
+     */
+    public $can_send_documents = false;
+
+    /**
+     * True, if the user is allowed to send photos
+     * @var bool
+     */
+    public $can_send_photos = false;
+
+    /**
+     * True, if the user is allowed to send videos
+     * @var bool
+     */
+    public $can_send_videos = false;
+
+    /**
+     * True, if the user is allowed to send video notes
+     * @var bool
+     */
+    public $can_send_video_notes = false;
+
+    /**
+     * True, if the user is allowed to send voice notes
+     * @var bool
+     */
+    public $can_send_voice_notes = false;
+
+    /**
+     * True, if the user is allowed to send polls
+     * @var bool
+     */
+    public $can_send_polls = false;
+
+    /**
+     * True, if the user is allowed to send animations, games, stickers and use inline bots
+     * @var bool
+     */
+    public $can_send_other_messages = false;
+
+    /**
+     * True, if the user is allowed to add web page previews to their messages
+     * @var bool
+     */
+    public $can_add_web_page_previews = false;
+
+    /**
+     * True, if the user is allowed to change the chat title, photo and other settings
+     * @var bool
+     */
+    public $can_change_info = false;
+
+    /**
+     * True, if the user is allowed to invite new users to the chat
+     * @var bool
+     */
+    public $can_invite_users = false;
+
+    /**
+     * True, if the user is allowed to pin messages
+     * @var bool
+     */
+    public $can_pin_messages = false;
+
+    /**
+     * True, if the user is allowed to create forum topics
+     * @var bool
+     */
+    public $can_manage_topics = false;
+
+    /**
+     * Date when restrictions will be lifted for this user; Unix time. If 0, then the user is restricted forever
+     * @var int
+     */
+    public $until_date = 0;
+
+}

--- a/src/Telegram/Types/ChatMemberUpdated.php
+++ b/src/Telegram/Types/ChatMemberUpdated.php
@@ -64,7 +64,7 @@ class ChatMemberUpdated extends TelegramTypes
                 return new User($data, $this->logger);
             case 'old_chat_member':
             case 'new_chat_member':
-                return new ChatMember($data, $this->logger);
+                return ChatMember::create($data, $this->logger);
             case 'invite_link':
                 return new ChatInviteLink($data, $this->logger);
         }

--- a/src/Telegram/Types/Custom/ChatMembersArray.php
+++ b/src/Telegram/Types/Custom/ChatMembersArray.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace unreal4u\TelegramAPI\Telegram\Types\Custom;
 
@@ -15,10 +15,8 @@ class ChatMembersArray extends TraversableCustomType
 {
     public function __construct(array $data = null, LoggerInterface $logger = null)
     {
-        if (count($data) !== 0) {
-            foreach ($data as $id => $chatMember) {
-                $this->data[$id] = new ChatMember($chatMember, $logger);
-            }
+        foreach ($data ?? [] as $id => $chatMember) {
+            $this->data[$id] = ChatMember::create($chatMember, $logger);
         }
     }
 }


### PR DESCRIPTION
This updates is mostly related to users. Here is quick overview of changes:

- Added public constants for `Chat` representing chat type (private, group, supergroup and channel)
- Added new Telegram type classes:
    - [ChatInviteLink](https://core.telegram.org/bots/api#chatinvitelink)
    - [ChatJoinRequest.php](https://core.telegram.org/bots/api#chatjoinrequest)
    - [ChatMemberUpdated](https://core.telegram.org/bots/api#chatmemberupdated)
    - updated [ChatMember](https://core.telegram.org/bots/api#chatmember) and added it's childs:
        - [ChatMemberOwner](https://core.telegram.org/bots/api#chatmemberowner)
        - [ChatMemberAdministrator](https://core.telegram.org/bots/api#chatmemberadministrator)
        - [ChatMemberMember](https://core.telegram.org/bots/api#chatmembermember)
        - [ChatMemberRestricted](https://core.telegram.org/bots/api#chatmemberrestricted)
        - [ChatMemberLeft](https://core.telegram.org/bots/api#chatmemberleft)
        - [ChatMemberBanned](https://core.telegram.org/bots/api#chatmemberbanned)
    - [ChatMemberUpdated](https://core.telegram.org/bots/api#chatmemberupdated)

- Few small improvements and refactoring

All touched classes were updated to match documentation (types and PHPDocs) as of [September 22, 2023 Bot API 6.9](https://core.telegram.org/bots/api-changelog#september-22-2023).